### PR TITLE
Release 2.0.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,21 @@
 # History
+
+## 2.0.1
+- Example: 
+    - Update dependencies.
+- Widget:
+    - Update dependencies
+    - Fix: use existing UploadcareClient instance instead of creating new one
+    - Fix: UploadCareWidget.selectFileFrom() didn't work with Camera/Video/File social networks
+    - Fix: possible issue when Social Source dialog items were not visible in dialog fragment on some devices
+- Library:
+    - Update dependencies
+    - Add support for batch store/delete calls for Files
+    - Set default UploadcareClient auth method to HMAC-based
+    - Fix: "Project" data model, now **UploadcareClient.getProject()** and **UploadcareClient.getProjectAsync()** work properly
+    - Internal network layer optimizations and improvements
+    
+
 ## 2.0.0
 - Example: Update dependencies, rewrite example to Kotlin.
 - Widget: Update dependencies, rewrite widget to Kotlin, Fixes, Add "Google Photos" support.

--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,14 @@ buildscript {
     versions.gradle_version = '3.3.2'
     versions.bintray_version = '0.9'
 
-    versions.core = "1.1.0-alpha05"
-    versions.material = "1.1.0-alpha05"
+    versions.core = "1.2.0-alpha03"
+    versions.material = "1.1.0-alpha09"
     versions.navigation = "2.0.0"
     versions.safe_args = "2.0.0"
-    versions.lifecycle = "2.1.0-alpha04"
-    versions.constraintlayout = "2.0.0-alpha3"
-    versions.annotation = '1.0.2'
-    versions.appcompat = "1.1.0-alpha04"
+    versions.lifecycle = "2.2.0-alpha03"
+    versions.constraintlayout = "2.0.0-beta1"
+    versions.annotation = '1.1.0'
+    versions.appcompat = "1.1.0-rc01"
 
     versions.okhttp = "3.13.1"
     versions.retrofit = "2.5.0"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     def versions = [:]
-    versions.kotlin_version = '1.3.21'
+    versions.kotlin_version = '1.3.41'
 
     versions.min_sdk = 22
     versions.target_sdk = 28

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -39,6 +39,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.uploadcare.android.example"
         minSdkVersion versions.min_sdk
         targetSdkVersion versions.target_sdk
-        versionCode 3
-        versionName "2.0.0"
+        versionCode 4
+        versionName "2.0.1"
     }
 
     dataBinding {

--- a/example/src/main/java/com/uploadcare/android/example/viewmodels/FilesViewModel.kt
+++ b/example/src/main/java/com/uploadcare/android/example/viewmodels/FilesViewModel.kt
@@ -11,6 +11,7 @@ import com.uploadcare.android.library.api.UploadcareFile
 import com.uploadcare.android.library.callbacks.UploadcareFilesCallback
 import com.uploadcare.android.library.exceptions.UploadcareApiException
 import com.uploadcare.android.library.urls.Order
+import com.uploadcare.android.widget.controller.UploadcareWidget
 import com.uploadcare.android.widget.utils.SingleLiveEvent
 import java.net.URI
 import java.util.*
@@ -36,7 +37,7 @@ class FilesViewModel(application: Application) : AndroidViewModel(application) {
     /**
      * Initialize {@link UploadcareClient}
      */
-    private val client = UploadcareClient.demoClient() // UploadcareClient("publickey", "privatekey") Use your public and private keys from Uploadcare.com account dashboard.
+    private val client = UploadcareWidget.getInstance(application).uploadcareClient
 
     fun launchFromPicker() {
         launchFromPickerCommand.call()

--- a/example/src/main/java/com/uploadcare/android/example/viewmodels/UploadViewModel.kt
+++ b/example/src/main/java/com/uploadcare/android/example/viewmodels/UploadViewModel.kt
@@ -37,7 +37,7 @@ class UploadViewModel(application: Application) : AndroidViewModel(application) 
     /**
      * Initialize {@link UploadcareClient}
      */
-    private val client = UploadcareClient.demoClient() // UploadcareClient("publickey", "privatekey") Use your public and private keys from Uploadcare.com account dashboard.
+    private val client = UploadcareWidget.getInstance(application).uploadcareClient
 
     fun launchGetFiles() {
         launchGetFilesCommand.call()

--- a/library/README.md
+++ b/library/README.md
@@ -22,7 +22,7 @@ Latest stable version is available from jCenter.
 To include it in your Android project, add this to the gradle.build file:
 
 ```
-implementation 'com.uploadcare.android.library:uploadcare-android:2.0.0'
+implementation 'com.uploadcare.android.library:uploadcare-android:2.0.1'
 
 ```
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion versions.min_sdk
         targetSdkVersion versions.target_sdk
-        versionCode 7
-        versionName "2.0.0"
+        versionCode 8
+        versionName "2.0.1"
     }
 
     androidExtensions {
@@ -63,7 +63,7 @@ publish {
     userOrg = properties.containsKey('bintray.user') ? properties.getProperty("bintray.user") : ""
     groupId = 'com.uploadcare.android.library'
     artifactId = 'uploadcare-android'
-    publishVersion = '2.0.0'
+    publishVersion = '2.0.1'
     desc = 'Android client library for the Uploadcare API.'
     licences = ["Apache-2.0"]
     website = 'https://github.com/uploadcare/uploadcare-android'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -44,6 +44,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     dokka {
         outputFormat = 'html'
         outputDirectory = "$buildDir/javadoc"

--- a/library/src/main/java/com/uploadcare/android/library/api/Project.kt
+++ b/library/src/main/java/com/uploadcare/android/library/api/Project.kt
@@ -1,11 +1,14 @@
 package com.uploadcare.android.library.api
 
+import com.squareup.moshi.Json
+
 /**
  * The resource for project, associated with the connecting account.
  */
 data class Project(val name: String,
-                   val pubKey: String,
-                   val collaborators: List<Collaborator>) {
+                   @Json(name = "pub_key") val pubKey: String,
+                   val collaborators: List<Collaborator>,
+                   @Json(name = "autostore_enabled") val autostoreEnabled: Boolean = false) {
 
     fun getOwner(): Collaborator? = if (collaborators.isNotEmpty()) {
         collaborators[0]

--- a/library/src/main/java/com/uploadcare/android/library/api/RequestHelper.kt
+++ b/library/src/main/java/com/uploadcare/android/library/api/RequestHelper.kt
@@ -68,7 +68,7 @@ class RequestHelper(private val client: UploadcareClient) {
         val calendar = GregorianCalendar(GMT)
         val formattedDate = rfc2822(calendar.time)
 
-        requestBuilder.addHeader("Content-Type", JSON_CONTENT_TYPE)
+        requestBuilder.addHeader("Content-Type", contentType?.let { it } ?: JSON_CONTENT_TYPE)
         requestBuilder.addHeader("Accept", "application/vnd.uploadcare-v0.5+json")
         requestBuilder.addHeader("Date", formattedDate)
         requestBuilder.addHeader("User-Agent",

--- a/library/src/main/java/com/uploadcare/android/library/api/RequestHelper.kt
+++ b/library/src/main/java/com/uploadcare/android/library/api/RequestHelper.kt
@@ -56,7 +56,7 @@ class RequestHelper(private val client: UploadcareClient) {
                       url: String,
                       requestType: String,
                       callback: BaseCallback<out Any>? = null) {
-        val calendar = GregorianCalendar(UTC)
+        val calendar = GregorianCalendar(GMT)
         val formattedDate = rfc2822(calendar.time)
 
         requestBuilder.addHeader("Accept", "application/vnd.uploadcare-v0.5+json")
@@ -507,11 +507,13 @@ class RequestHelper(private val client: UploadcareClient) {
 
         const val REQUEST_PUT = "PUT"
 
-        const val DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss Z"
+        const val DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z"
 
         const val DATE_FORMAT_ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 
         val UTC = TimeZone.getTimeZone("UTC")
+
+        val GMT = TimeZone.getTimeZone("GMT")
 
         private const val EMPTY_MD5 = "d41d8cd98f00b204e9800998ecf8427e"
 
@@ -519,7 +521,7 @@ class RequestHelper(private val client: UploadcareClient) {
 
         @JvmStatic
         fun rfc2822(date: Date) = SimpleDateFormat(DATE_FORMAT, Locale.US).apply {
-            timeZone = UTC
+            timeZone = GMT
         }.format(date)
 
         @JvmStatic

--- a/library/src/main/java/com/uploadcare/android/library/api/UploadcareClient.kt
+++ b/library/src/main/java/com/uploadcare/android/library/api/UploadcareClient.kt
@@ -372,7 +372,7 @@ class UploadcareClient constructor(val publicKey: String,
         }
         val formBody = formBuilder.build()
         return requestHelper.executeQuery(RequestHelper.REQUEST_POST, url.toString(), true,
-                CopyFileData::class.java, formBody)
+                CopyFileData::class.java, formBody, formBody.md5())
     }
 
     /**
@@ -393,7 +393,7 @@ class UploadcareClient constructor(val publicKey: String,
         val formBody = formBuilder.build()
 
         requestHelper.executeQueryAsync(context, RequestHelper.REQUEST_POST, url.toString(), true,
-                CopyFileData::class.java, callback, formBody)
+                CopyFileData::class.java, callback, formBody, formBody.md5())
     }
 
     companion object {

--- a/library/src/main/java/com/uploadcare/android/library/api/UploadcareClient.kt
+++ b/library/src/main/java/com/uploadcare/android/library/api/UploadcareClient.kt
@@ -1,12 +1,16 @@
 package com.uploadcare.android.library.api
 
 import android.content.Context
+import com.squareup.moshi.Types
 import com.uploadcare.android.library.BuildConfig
+import com.uploadcare.android.library.api.RequestHelper.Companion.md5
 import com.uploadcare.android.library.callbacks.*
-import com.uploadcare.android.library.data.*
+import com.uploadcare.android.library.data.CopyFileData
+import com.uploadcare.android.library.data.ObjectMapper
 import com.uploadcare.android.library.urls.Urls
 import okhttp3.*
 import okhttp3.logging.HttpLoggingInterceptor
+import okio.ByteString
 import java.util.concurrent.TimeUnit
 
 /**
@@ -206,6 +210,55 @@ class UploadcareClient constructor(val publicKey: String,
     }
 
     /**
+     * Marks a files as deleted.
+     * Maximum 100 file id's can be provided.
+     *
+     * @param fileIds  Resource UUIDs
+     */
+    fun deleteFiles(fileIds: List<String>) {
+        val url = Urls.apiFilesBatch()
+        val requestBodyContent = objectMapper.toJson(fileIds,
+                Types.newParameterizedType(List::class.java, String::class.java))
+        val body = RequestBody.create(RequestHelper.JSON, ByteString.encodeUtf8(requestBodyContent))
+        requestHelper.executeCommand(RequestHelper.REQUEST_DELETE, url.toString(), true, body,
+                requestBodyContent.md5())
+    }
+
+    /**
+     * Marks multiple files as deleted Asynchronously.
+     * Maximum 100 file id's can be provided.
+     *
+     * @param context Application context. [android.content.Context]
+     * @param fileIds  Resource UUIDs
+     */
+    fun deleteFilesAsync(context: Context, fileIds: List<String>) {
+        val url = Urls.apiFilesBatch()
+        val requestBodyContent = objectMapper.toJson(fileIds,
+                Types.newParameterizedType(List::class.java, String::class.java))
+        val body = RequestBody.create(RequestHelper.JSON, ByteString.encodeUtf8(requestBodyContent))
+        requestHelper.executeCommandAsync(context, RequestHelper.REQUEST_DELETE, url.toString(),
+                true, null, body, requestBodyContent.md5())
+    }
+
+    /**
+     * Marks multiple files as deleted Asynchronously.
+     * Maximum 100 file id's can be provided.
+     *
+     * @param context  Application context. [android.content.Context]
+     * @param fileIds  Resource UUIDs
+     * @param callback callback  [RequestCallback] with either
+     * an HTTP response or a failure exception.
+     */
+    fun deleteFilesAsync(context: Context, fileIds: List<String>, callback: RequestCallback? = null) {
+        val url = Urls.apiFilesBatch()
+        val requestBodyContent = objectMapper.toJson(fileIds,
+                Types.newParameterizedType(List::class.java, String::class.java))
+        val body = RequestBody.create(RequestHelper.JSON, ByteString.encodeUtf8(requestBodyContent))
+        requestHelper.executeCommandAsync(context, RequestHelper.REQUEST_DELETE, url.toString(),
+                true, callback, body, requestBodyContent.md5())
+    }
+
+    /**
      * Marks a file as saved.
      *
      * This has to be done for all files you want to keep.
@@ -247,6 +300,61 @@ class UploadcareClient constructor(val publicKey: String,
         val url = Urls.apiFileStorage(fileId)
         requestHelper.executeCommandAsync(context, RequestHelper.REQUEST_POST, url.toString(), true,
                 callback)
+    }
+
+    /**
+     * Marks multiple files as saved.
+     *
+     * This has to be done for all files you want to keep.
+     * Unsaved files are eventually purged.
+     *
+     * @param fileIds  Resource UUIDs
+     */
+    fun saveFiles(fileIds: List<String>) {
+        val url = Urls.apiFilesBatch()
+        val requestBodyContent = objectMapper.toJson(fileIds,
+                Types.newParameterizedType(List::class.java, String::class.java))
+        val body = RequestBody.create(RequestHelper.JSON, ByteString.encodeUtf8(requestBodyContent))
+        requestHelper.executeCommand(RequestHelper.REQUEST_PUT, url.toString(), true, body,
+                requestBodyContent.md5())
+    }
+
+    /**
+     * Marks multiple files as saved Asynchronously.
+     *
+     * This has to be done for all files you want to keep.
+     * Unsaved files are eventually purged.
+     *
+     * @param context Application context. [android.content.Context]
+     * @param fileIds  Resource UUIDs
+     */
+    fun saveFilesAsync(context: Context, fileIds: List<String>) {
+        val url = Urls.apiFilesBatch()
+        val requestBodyContent = objectMapper.toJson(fileIds,
+                Types.newParameterizedType(List::class.java, String::class.java))
+        val body = RequestBody.create(RequestHelper.JSON, ByteString.encodeUtf8(requestBodyContent))
+        requestHelper.executeCommandAsync(context, RequestHelper.REQUEST_PUT, url.toString(),
+                true, null, body, requestBodyContent.md5())
+    }
+
+    /**
+     * Marks multiple files as saved Asynchronously.
+     *
+     * This has to be done for all files you want to keep.
+     * Unsaved files are eventually purged.
+     *
+     * @param context  Application context. @link android.content.Context
+     * @param fileIds  Resource UUIDs
+     * @param callback callback  [RequestCallback] with either
+     * an HTTP response or a failure exception.
+     */
+    fun saveFilesAsync(context: Context, fileIds: List<String>, callback: RequestCallback? = null) {
+        val url = Urls.apiFilesBatch()
+        val requestBodyContent = objectMapper.toJson(fileIds,
+                Types.newParameterizedType(List::class.java, String::class.java))
+        val body = RequestBody.create(RequestHelper.JSON, ByteString.encodeUtf8(requestBodyContent))
+        requestHelper.executeCommandAsync(context, RequestHelper.REQUEST_PUT, url.toString(),
+                true, callback, body, requestBodyContent.md5())
     }
 
     /**

--- a/library/src/main/java/com/uploadcare/android/library/api/UploadcareClient.kt
+++ b/library/src/main/java/com/uploadcare/android/library/api/UploadcareClient.kt
@@ -15,13 +15,14 @@ import java.util.concurrent.TimeUnit
  *
  * @param publicKey  Public key
  * @param privateKey Private key
- * @param simpleAuth If {@code false}, HMAC-based authentication is used
+ * @param simpleAuth If {@code false}, HMAC-based authentication is used, otherwise simple
+ * authentication is used.
  */
 class UploadcareClient constructor(val publicKey: String,
                                    val privateKey: String,
-                                   val simpleAuth: Boolean = true) {
+                                   val simpleAuth: Boolean = false) {
 
-    constructor(publicKey: String, privateKey: String) : this(publicKey, privateKey, true)
+    constructor(publicKey: String, privateKey: String) : this(publicKey, privateKey, false)
 
     val httpClient: OkHttpClient
     val requestHelper: RequestHelper

--- a/library/src/main/java/com/uploadcare/android/library/urls/Urls.kt
+++ b/library/src/main/java/com/uploadcare/android/library/urls/Urls.kt
@@ -84,6 +84,16 @@ class Urls private constructor() {
         }
 
         /**
+         * Creates a URL to the storage action for a multiple files (saving/deleting the files).
+         *
+         * @see com.uploadcare.android.library.api.UploadcareClient
+         */
+        @JvmStatic
+        fun apiFilesBatch(): URI {
+            return URI.create("$API_BASE/files/storage/")
+        }
+
+        /**
          * Creates a URL to the group collection resource.
          *
          * @see com.uploadcare.android.library.api.UploadcareClient

--- a/library/src/main/java/com/uploadcare/android/library/urls/Urls.kt
+++ b/library/src/main/java/com/uploadcare/android/library/urls/Urls.kt
@@ -11,7 +11,7 @@ class Urls private constructor() {
 
     companion object {
 
-        private const val API_BASE = "https://api.uploadcare.com"
+        internal const val API_BASE = "https://api.uploadcare.com"
         private const val CDN_BASE = "https://ucarecdn.com"
         private const val UPLOAD_BASE = "https://upload.uploadcare.com"
 

--- a/widget/README.md
+++ b/widget/README.md
@@ -19,7 +19,7 @@ Latest stable version is available from jCenter.
 To include it in your Android project, add this to the gradle.build file:
 
 ```
-implementation 'com.uploadcare.android.widget:uploadcare-android-widget:2.0.0'
+implementation 'com.uploadcare.android.widget:uploadcare-android-widget:2.0.1'
 
 ```
 

--- a/widget/build.gradle
+++ b/widget/build.gradle
@@ -62,6 +62,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     dokka {
         outputFormat = 'html'
         outputDirectory = "$buildDir/javadoc"

--- a/widget/build.gradle
+++ b/widget/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion versions.min_sdk
         targetSdkVersion versions.target_sdk
-        versionCode 6
-        versionName "2.0.0"
+        versionCode 7
+        versionName "2.0.1"
     }
 
     dataBinding {
@@ -81,7 +81,7 @@ publish {
     userOrg = properties.containsKey('bintray.user') ? properties.getProperty("bintray.user") : ""
     groupId = 'com.uploadcare.android.widget'
     artifactId = 'uploadcare-android-widget'
-    publishVersion = '2.0.0'
+    publishVersion = '2.0.1'
     desc = 'Android client library for the Uploadcare API.'
     licences = ["Apache-2.0"]
     website = 'https://github.com/uploadcare/uploadcare-android'

--- a/widget/src/main/java/com/uploadcare/android/widget/adapter/SocialNetworksAdapter.kt
+++ b/widget/src/main/java/com/uploadcare/android/widget/adapter/SocialNetworksAdapter.kt
@@ -52,6 +52,8 @@ class SocialNetworksAdapter(context: Context,
         binding.adapter = this
         binding.socialSource = getItem(position)
         binding.executePendingBindings()
+        // Invalidate to make sure view correctly calculates it's size inside DialogFragment.
+        binding.invalidateAll()
 
         return binding.root
     }


### PR DESCRIPTION
Update Library/Widget/Example to version to 2.0.1

- Example: 
    - Update dependencies.
- Widget:
    - Update dependencies
    - Fix: use existing UploadcareClient instance instead of creating new one
    - Fix: UploadCareWidget.selectFileFrom() didn't work with Camera/Video/File social networks
    - Fix: possible issue when Social Source dialog items were not visible in dialog fragment on some devices
- Library:
    - Update dependencies
    - Add support for batch store/delete calls for Files
    - Set default UploadcareClient auth method to HMAC-based
    - Fix: "Project" data model, now **UploadcareClient.getProject()** and **UploadcareClient.getProjectAsync()** work properly
    - Internal network layer optimizations and improvements

Closes: #18 , #17 , #19 