### PR TITLE
bugfix: UploadcareClient class visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.3.0
 **Library changes:**
 - Added convert methods with result data
+- Updated Proguard's rules to keep public classes
 
 ## 4.2.0
 **Library changes:**

--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -18,9 +18,4 @@
 
 -dontwarn java.lang.invoke.StringConcatFactory
 
--keep class com.uploadcare.android.library.data.** { *; }
--keep class com.uploadcare.android.library.api.Project { *; }
--keep class com.uploadcare.android.library.api.UploadcareCopyFile { *; }
--keep class com.uploadcare.android.library.api.UploadcareFile { *; }
--keep class com.uploadcare.android.library.api.UploadcareGroup { *; }
--keep class com.uploadcare.android.library.api.UploadcareWebhook { *; }
+-keep class com.uploadcare.android.library.** { *; }

--- a/widget/proguard-rules.pro
+++ b/widget/proguard-rules.pro
@@ -16,7 +16,7 @@
 #   public *;
 #}
 
--keep class com.uploadcare.android.widget.data.** { *; }
+-keep class com.uploadcare.android.widget.** { *; }
 
 # Keep inherited services.
 -if interface * { @retrofit2.http.* <methods>; }


### PR DESCRIPTION
## Description

- Adds wider proguard rules, to be sure that the whole public API of the library and the client is accessible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ProGuard rules to simplify class keep directives for better maintainability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->